### PR TITLE
Adds support for parsing a base image reference into components.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Configure the plugin by changing `registry`, `repository`, and `credentialHelper
 
 #### I am using Google Container Registry (GCR)
 
-*TODO: Add reference for how to get the credential helper.*
+*Make sure you have the [`docker-credential-gcr` command line tool](https://cloud.google.com/container-registry/docs/advanced-authentication#docker_credential_helper).*
 
 For example, to build the image `gcr.io/my-gcp-project/my-app`, the configuration would be:
 
@@ -55,7 +55,7 @@ For example, to build the image `gcr.io/my-gcp-project/my-app`, the configuratio
 
 #### I am using Amazon Elastic Container Registry (ECR)
 
-*TODO: Add reference for how to get the credential helper.*
+*Make sure you have the [`docker-credential-ecr-login` command line tool](https://github.com/awslabs/amazon-ecr-credential-helper).*
 
 For example, to build the image `aws_account_id.dkr.ecr.region.amazonaws.com/my-app`, the configuration would be:
 
@@ -85,15 +85,35 @@ Extended configuration options provide additional options for customizing the im
 
 Field | Default | Description
 --- | --- | ---
-from|`gcr.io/distroless/java`|The base image to build your application on top of.
-baseImageRegistry|`gcr.io`|The registry for the base image
-baseImageRepository|`distroless/java`|The image name/repository of the base image
-baseImageTag|`latest`|The tag for the base image
-registry|*Required*|The registry server to push the built image to.
-repository|*Required*|The image name/repository of the built image.
-tag|`latest`|The image tag of the built image (the part after the colon).
-jvmFlags|*None*|Additional flags to pass into the JVM when running your application.
-credentialHelperName|*Required*|The credential helper suffix (following `docker-credential-`)
+`from`|`gcr.io/distroless/java`|The base image to build your application on top of.
+`registry`|*Required*|The registry server to push the built image to.
+`repository`|*Required*|The image name/repository of the built image.
+`tag`|`latest`|The image tag of the built image (the part after the colon).
+`jvmFlags`|*None*|Additional flags to pass into the JVM when running your application.
+`credentialHelperName`|*Required*|The credential helper suffix (following `docker-credential-`)
+`mainClass`|Uses `mainClass` from `maven-jar-plugin`|The main class to launch the application from.
+
+### Example
+
+In this configuration, the image is:
+* Built from a base of `openjdk:alpine` (pulled from Docker Hub)
+* Pushed to `localhost:5000/my-image:built-with-jib`
+* Runs by calling `java -Xms512m -Xdebug -Xmy:flag=jib-rules -cp app/libs/*:app/resources:app/classes mypackage.MyApp`
+
+```
+<configuration>
+    <from>openjdk:alpine</from>
+    <registry>localhost:5000</registry>
+    <repository>my-image</repository>
+    <tag>built-with-jib</tag>
+    <jvmFlags>
+        <jvmFlag>-Xms512m</jvmFlag>
+        <jvmFlag>-Xdebug</jvmFlag>
+        <jvmFlag>-Xmy:flag=jib-rules</jvmFlag>
+    </jvmFlags>
+    <mainClass>mypackage.MyApp</mainClass>
+</configuration>
+```
 
 ## How Jib Works
 
@@ -104,6 +124,8 @@ See also [rules_docker](https://github.com/bazelbuild/rules_docker) for a simila
 ## Frequently Asked Questions (FAQ)
 
 *TODO: Add more answers.*
+
+If a question you have is not answered before, please [submit an issue](/../../issues/new).
 
 ### But, I'm not a Java developer.
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/DescriptorDigest.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/DescriptorDigest.java
@@ -41,7 +41,7 @@ public class DescriptorDigest {
   private static final String DIGEST_PREFIX = "sha256:";
 
   /** Pattern matches a SHA-256 digest - a SHA-256 hash prefixed with "sha256:". */
-  private static final String DIGEST_REGEX = DIGEST_PREFIX + HASH_REGEX;
+  static final String DIGEST_REGEX = DIGEST_PREFIX + HASH_REGEX;
 
   private final String hash;
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageReference.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageReference.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.image;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Represents an image reference.
+ *
+ * @see <a
+ *     href="https://github.com/docker/distribution/blob/master/reference/reference.go">https://github.com/docker/distribution/blob/master/reference/reference.go</a>
+ * @see <a
+ *     href="https://docs.docker.com/engine/reference/commandline/tag/#extended-description">https://docs.docker.com/engine/reference/commandline/tag/#extended-description</a>
+ */
+public class ImageReference {
+
+  private static final String DOCKER_HUB_REGISTRY = "registry.hub.docker.com";
+  private static final String DEFAULT_TAG = "latest";
+
+  /**
+   * Matches all sequences of alphanumeric characters possibly separated by any number of dashes in
+   * the middle.
+   */
+  private static final String REGISTRY_COMPONENT_REGEX =
+      "(?:[a-zA-Z\\d]|(?:[a-zA-Z\\d][a-zA-Z\\d-]*[a-zA-Z\\d]))";
+
+  /**
+   * Matches sequences of {@code REGISTRY_COMPONENT_REGEX} separated by a dot, with an optional
+   * {@code :port} at the end.
+   */
+  private static final String REGISTRY_REGEX =
+      String.format("%s(?:\\.%s)*(?::\\d+)?", REGISTRY_COMPONENT_REGEX, REGISTRY_COMPONENT_REGEX);
+
+  /**
+   * Matches all sequences of alphanumeric characters separated by a separator.
+   *
+   * <p>A separator is either an underscore, a dot, two underscores, or any number of dashes.
+   */
+  private static final String REPOSITORY_COMPONENT_REGEX =
+      "[a-z\\d]+(?:(?:[_.]|__|[-]*)[a-z\\d]+)*";
+
+  /** Matches all repetitions of {@code REPOSITORY_COMPONENT_REGEX} separated by a backslash. */
+  private static final String REPOSITORY_REGEX =
+      String.format("(?:%s/)*%s", REPOSITORY_COMPONENT_REGEX, REPOSITORY_COMPONENT_REGEX);
+
+  /** Matches a tag of max length 128. */
+  private static final String TAG_REGEX = "[\\w][\\w.-]{0,127}";
+
+  /**
+   * Matches a full image reference, which is the registry, repository, and tag/digest separated by
+   * backslashes. The repository is required, but the registry and tag/digest are optional.
+   */
+  private static final String REFERENCE_REGEX =
+      String.format(
+          "^(?:(%s)/)?(%s)(?:(?::(%s))|(?:@(%s)))?$",
+          REGISTRY_REGEX, REPOSITORY_REGEX, TAG_REGEX, DescriptorDigest.DIGEST_REGEX);
+
+  private static final Pattern REFERENCE_PATTERN = Pattern.compile(REFERENCE_REGEX);
+
+  /** Parses an image reference. */
+  public static ImageReference parse(String reference) throws InvalidImageReferenceException {
+    Matcher matcher = REFERENCE_PATTERN.matcher(reference);
+
+    if (!matcher.find() || matcher.groupCount() < 4) {
+      throw new InvalidImageReferenceException(reference);
+    }
+
+    String registry = matcher.group(1);
+    String repository = matcher.group(2);
+    String tag = matcher.group(3);
+    String digest = matcher.group(4);
+
+    // If no registry was matched, use Docker Hub by default.
+    if (Strings.isNullOrEmpty(registry)) {
+      registry = DOCKER_HUB_REGISTRY;
+    }
+
+    if (Strings.isNullOrEmpty(repository)) {
+      throw new InvalidImageReferenceException(reference);
+    }
+    /*
+     * If a registry was matched but it does not contain any dots or colons, it should actually be
+     * part of the repository unless it is "localhost".
+     *
+     * See https://github.com/docker/distribution/blob/245ca4659e09e9745f3cc1217bf56e946509220c/reference/normalize.go#L62
+     */
+    if (!registry.contains(".") && !registry.contains(":") && !"localhost".equals(registry)) {
+      repository = registry + "/" + repository;
+      registry = DOCKER_HUB_REGISTRY;
+    }
+    /*
+     * For Docker Hub, if the repository is only one component, then it should be prefixed with
+     * 'library/'.
+     *
+     * See https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-from-docker-hub
+     */
+    if (DOCKER_HUB_REGISTRY.equals(registry) && repository.indexOf('/') < 0) {
+      repository = "library/" + repository;
+    }
+
+    if (!Strings.isNullOrEmpty(tag)) {
+      if (!Strings.isNullOrEmpty(digest)) {
+        // Cannot have matched both tag and digest.
+        throw new InvalidImageReferenceException(reference);
+      }
+    } else if (!Strings.isNullOrEmpty(digest)) {
+      tag = digest;
+    } else {
+      tag = DEFAULT_TAG;
+    }
+
+    return new ImageReference(registry, repository, tag);
+  }
+
+  private final String registry;
+  private final String repository;
+  private final String tag;
+
+  /** Use {@link #parse} to construct. */
+  @VisibleForTesting
+  ImageReference(String registry, String repository, String tag) {
+    this.registry = registry;
+    this.repository = repository;
+    this.tag = tag;
+  }
+
+  public String getRegistry() {
+    return registry;
+  }
+
+  public String getRepository() {
+    return repository;
+  }
+
+  public String getTag() {
+    return tag;
+  }
+}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/InvalidImageReferenceException.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/InvalidImageReferenceException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.image;
+
+/** Thrown when attempting to parse an invalid image reference. */
+public class InvalidImageReferenceException extends Exception {
+
+  public InvalidImageReferenceException(String reference) {
+    super("Invalid image reference: " + reference);
+  }
+}

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/ImageReferenceTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/ImageReferenceTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.image;
+
+import com.google.common.base.Strings;
+import java.util.Arrays;
+import java.util.List;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+/** Tests for {@link ImageReference}. */
+public class ImageReferenceTest {
+
+  private static final List<String> goodRegistries =
+      Arrays.asList("some.domain---name.123.com:8080", "gcr.io", "localhost", null, "");
+  private static final List<String> goodRepositories =
+      Arrays.asList("some123_abc/repository__123-456/name---here", "distroless/java", "repository");
+  private static final List<String> goodTags = Arrays.asList("some-.-.Tag", "", "latest", null);
+  private static final List<String> goodDigests =
+      Arrays.asList(
+          "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", null);
+
+  private static final List<String> badImageReferences =
+      Arrays.asList(
+          "",
+          ":justsometag",
+          "@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "repository@sha256:a",
+          "repository@notadigest",
+          "Repositorywithuppercase",
+          "registry:8080/Repositorywithuppercase/repository:sometag",
+          "domain.name:nonnumberport/repository",
+          "domain.name:nonnumberport//:no-repository");
+
+  @Test
+  public void testParse_pass() throws InvalidImageReferenceException {
+    for (String goodRegistry : goodRegistries) {
+      for (String goodRepository : goodRepositories) {
+        for (String goodTag : goodTags) {
+          verifyParse(goodRegistry, goodRepository, ":", goodTag);
+        }
+        for (String goodDigest : goodDigests) {
+          verifyParse(goodRegistry, goodRepository, "@", goodDigest);
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testParse_dockerHub_official() throws InvalidImageReferenceException {
+    String imageReferenceString = "busybox";
+    ImageReference imageReference = ImageReference.parse(imageReferenceString);
+
+    Assert.assertEquals("registry.hub.docker.com", imageReference.getRegistry());
+    Assert.assertEquals("library/busybox", imageReference.getRepository());
+    Assert.assertEquals("latest", imageReference.getTag());
+  }
+
+  @Test
+  public void testParse_dockerHub_user() throws InvalidImageReferenceException {
+    String imageReferenceString = "someuser/someimage";
+    ImageReference imageReference = ImageReference.parse(imageReferenceString);
+
+    Assert.assertEquals("registry.hub.docker.com", imageReference.getRegistry());
+    Assert.assertEquals("someuser/someimage", imageReference.getRepository());
+    Assert.assertEquals("latest", imageReference.getTag());
+  }
+
+  @Test
+  public void testParse_invalid() {
+    for (String badImageReference : badImageReferences) {
+      try {
+        ImageReference.parse(badImageReference);
+        Assert.fail(badImageReference + " should not be a valid image reference");
+
+      } catch (InvalidImageReferenceException ex) {
+        Assert.assertThat(ex.getMessage(), CoreMatchers.containsString(badImageReference));
+      }
+    }
+  }
+
+  private void verifyParse(String registry, String repository, String tagSeparator, String tag)
+      throws InvalidImageReferenceException {
+    // Gets the expected parsed components.
+    String expectedRegistry = registry;
+    if (Strings.isNullOrEmpty(expectedRegistry)) {
+      expectedRegistry = "registry.hub.docker.com";
+    }
+    String expectedRepository = repository;
+    if ("registry.hub.docker.com".equals(expectedRegistry) && repository.indexOf('/') < 0) {
+      expectedRepository = "library/" + expectedRepository;
+    }
+    String expectedTag = tag;
+    if (Strings.isNullOrEmpty(expectedTag)) {
+      expectedTag = "latest";
+    }
+
+    // Builds the image reference to parse.
+    StringBuilder imageReferenceBuilder = new StringBuilder();
+    if (!Strings.isNullOrEmpty(registry)) {
+      imageReferenceBuilder.append(registry).append('/');
+    }
+    imageReferenceBuilder.append(repository);
+    if (!Strings.isNullOrEmpty(tag)) {
+      imageReferenceBuilder.append(tagSeparator).append(tag);
+    }
+
+    ImageReference imageReference = ImageReference.parse(imageReferenceBuilder.toString());
+
+    Assert.assertEquals(expectedRegistry, imageReference.getRegistry());
+    Assert.assertEquals(expectedRepository, imageReference.getRepository());
+    Assert.assertEquals(expectedTag, imageReference.getTag());
+  }
+}


### PR DESCRIPTION
Fixes #28 

Adds `from` parameter to plugin to replace the separate `baseImageRegistry`, `baseImageRepository`, and `baseImageTag` configuration parameters.