### PR TITLE
Fixes Kokoro build script.

### DIFF
--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     compile 'com.fasterxml.jackson.core:jackson-databind:2.9.2'
     compile 'org.slf4j:slf4j-api:1.7.25'
     testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:2.7.1'
+    testCompile 'org.mockito:mockito-core:2.12.0'
 }
 
 jar {

--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     compile 'com.fasterxml.jackson.core:jackson-databind:2.9.2'
     compile 'org.slf4j:slf4j-api:1.7.25'
     testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:2.12.0'
+    testCompile 'org.mockito:mockito-core:2.7.1'
 }
 
 jar {

--- a/kokoro/continuous.bat
+++ b/kokoro/continuous.bat
@@ -6,3 +6,4 @@ cd jib-core && call gradlew.bat clean build publishToMavenLocal --info
 cd ../jib-maven-plugin && call mvnw.cmd clean install cobertura:cobertura -B -U -X
 
 exit /b %ERRORLEVEL%
+g

--- a/kokoro/continuous.bat
+++ b/kokoro/continuous.bat
@@ -2,7 +2,7 @@
 
 cd github/jib
 
-cd jib-core && call gradlew.bat clean build --info
+cd jib-core && call gradlew.bat clean build publishToMavenLocal --info
 cd ../jib-maven-plugin && call mvnw.cmd clean install cobertura:cobertura -B -U -X
 
 exit /b %ERRORLEVEL%

--- a/kokoro/continuous.sh
+++ b/kokoro/continuous.sh
@@ -5,5 +5,5 @@ set -x
 
 cd github/jib
 
-(cd jib-core; ./gradlew clean build --info)
+(cd jib-core; ./gradlew clean build publishToMavenLocal--info)
 (cd jib-maven-plugin; ./mvnw clean install cobertura:cobertura -B -U -X)

--- a/kokoro/continuous.sh
+++ b/kokoro/continuous.sh
@@ -5,5 +5,5 @@ set -x
 
 cd github/jib
 
-(cd jib-core; ./gradlew clean build publishToMavenLocal--info)
+(cd jib-core; ./gradlew clean build publishToMavenLocal --info)
 (cd jib-maven-plugin; ./mvnw clean install cobertura:cobertura -B -U -X)


### PR DESCRIPTION
The `jib-maven-plugin` test needs `jib-core` to be installed into the local Maven repo.