### PR TITLE
Adds Kokoro release scripts.

### DIFF
--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'checkstyle'
     id 'com.github.sherter.google-java-format' version '0.6'
     id 'maven-publish'
+    id 'maven'
 }
 
 group 'com.google.cloud.tools'
@@ -31,7 +32,6 @@ configurations {
 }
 
 dependencies {
-    compile gradleApi()
     compile 'com.google.http-client:google-http-client:1.23.0'
     compile 'org.apache.commons:commons-compress:1.15'
     compile 'com.google.guava:guava:23.5-jre'
@@ -101,3 +101,10 @@ checkstyle {
     maxWarnings = 0
 }
 /* CHECKSTYLE */
+
+// Writes a pom.xml for adding the corresponding dependencies to jib-maven-plugin.
+task writePom {
+    doLast {
+        pom {}.writeTo("$buildDir/pom.xml")
+    }
+}

--- a/jib-maven-plugin/kokoro/release_build.sh
+++ b/jib-maven-plugin/kokoro/release_build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Fail on any error.
+set -e
+# Display commands to stderr.
+set -x
+
+cd github/jib/jib-maven-plugin
+./mvnw -Prelease -B -U verify
+
+# copy pom with the name expected in the Maven repository
+ARTIFACT_ID=$(mvn -B help:evaluate -Dexpression=project.artifactId 2>/dev/null | grep -v "^\[")
+PROJECT_VERSION=$(mvn -B help:evaluate -Dexpression=project.version 2>/dev/null| grep -v "^\[")
+cp pom.xml target/${ARTIFACT_ID}-${PROJECT_VERSION}.pom

--- a/jib-maven-plugin/kokoro/release_publish.sh
+++ b/jib-maven-plugin/kokoro/release_publish.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Fail on any error.
+set -e
+
+CREDENTIALS="$SONATYPE_USERNAME:$SONATYPE_PASSWORD"
+
+# Display commands to stderr.
+set -x
+
+# Goes to the GCS directory.
+cd $KOKORO_GFILE_DIR
+
+# Finds the latest ubuntu/release-sign build directory.
+LAST_BUILD=$(ls prod/jib/maven/ubuntu/release-sign/ | sort -rV | head -1)
+
+# Finds the bundled jar file in the latest signed artifact directory.
+BUNDLED_JAR_FILE=$(find `pwd`/prod/jib/maven/ubuntu/release-sign/${LAST_BUILD}/* -type f \( -iname \*-bundle.jar \))
+
+# Usage: GetSessionID <variable name>
+# Uses the environment variable CREDENTIALS.
+# Stores the Nexus session ID in the given variable.
+GetSessionID() {
+	local __resultvar=$1
+
+	# Makes a temporary file to store the login cookies.
+	local cookies_temp=$(mktemp /tmp/sonatype_cookies.XXXXXXX)
+
+	# Sends a login request.
+	{ local login_response=$(curl 'https://oss.sonatype.org/service/local/authentication/login' -X 'GET' -u "$CREDENTIALS" -c $cookies_temp 2> /dev/null); } 2> /dev/null
+
+	# Checks if login was successful.
+	echo $login_response | grep -q '<loggedIn>true</loggedIn>'
+
+	local login_check=$(echo -n $?)
+
+	if [ "$login_check" -eq "1" ]; then
+		return 1
+	fi
+
+	# Extracts the session ID from the cookies.
+	local nxsessionid
+	local nxsessionid_line=$(cat $cookies_temp | grep 'NXSESSIONID')
+	nxsessionid=$(echo -n $nxsessionid_line | awk '{print $NF}')
+
+	eval $__resultvar="'$nxsessionid'"
+}
+
+# Usage: UploadJAR <session ID> <file>
+# Uploads the bundled JAR file to the Nexus Staging Repository.
+UploadJAR() {
+	curl 'https://oss.sonatype.org/service/local/staging/bundle_upload' -H "Cookie: NXSESSIONID=$1" -H 'Content-Type: multipart/form-data' --compressed -F "file=@$2"
+}
+
+# Gets the session ID.
+GetSessionID NXSESSIONID
+if [ $? -eq 1 ]; then
+	echo 'Login failed!'
+	exit 1
+fi
+echo 'Login successful.'
+
+# Uploads the bundled JAR file.
+echo 'Uploading artifact...'
+UploadJAR $NXSESSIONID $BUNDLED_JAR_FILE

--- a/jib-maven-plugin/kokoro/release_sign.sh
+++ b/jib-maven-plugin/kokoro/release_sign.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Fail on any error.
+set -e
+# Display commands being run.
+set -x
+
+cd $KOKORO_GFILE_DIR
+mkdir signed && chmod 777 signed
+
+# find the latest directory under prod/jib/maven/gcp_ubuntu/release-build/
+LAST_BUILD=$(ls prod/jib/maven/gcp_ubuntu/release-build/ | sort -rV | head -1)
+
+# find the jars and the pom in the latest build artifact directory
+FILES=$(find `pwd`/prod/jib/maven/gcp_ubuntu/release-build/${LAST_BUILD}/* -type f \( -iname \*.jar -o -iname \*.pom \))
+
+for f in $FILES
+do
+  echo "Processing $f file..."
+  filename=$(basename "$f")
+  mv $f signed/$filename
+  if /escalated_sign/escalated_sign.py -j /escalated_sign_jobs -t linux_gpg_sign \
+    `pwd`/signed/$filename
+  then echo "Signed $filename"
+  else
+    echo "Could not sign $filename"
+    exit 1
+  fi
+done
+
+# bundle the artifacts for manual deploy to the Maven staging repository
+cd signed
+POM_NAME=$(ls *.pom)
+BUNDLE_NAME=${POM_NAME%.pom}-bundle.jar
+jar -cvf ${BUNDLE_NAME} *

--- a/jib-maven-plugin/pom.xml
+++ b/jib-maven-plugin/pom.xml
@@ -94,6 +94,41 @@
         </plugins>
       </build>
     </profile>
+
+    <!-- Profile for releasing. -->
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.0.0</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.0.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <build>

--- a/jib-maven-plugin/pom.xml
+++ b/jib-maven-plugin/pom.xml
@@ -159,12 +159,14 @@
 
   <build>
     <plugins>
-      <!-- Imports jib-core source -->
+      <!-- Imports jib-core sources -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.0.0</version>
         <executions>
           <execution>
+            <id>add-jib-core-sources</id>
             <phase>generate-sources</phase>
             <goals>
               <goal>add-source</goal>
@@ -173,6 +175,32 @@
               <sources>
                 <source>../jib-core/src/main/java</source>
               </sources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-jib-core-test-sources</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>../jib-core/src/test/java</source>
+              </sources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-jib-core-test-resources</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>add-test-resource</goal>
+            </goals>
+            <configuration>
+              <resources>
+                <resource>
+                  <directory>../jib-core/src/test/resources</directory>
+                </resource>
+              </resources>
             </configuration>
           </execution>
         </executions>

--- a/jib-maven-plugin/pom.xml
+++ b/jib-maven-plugin/pom.xml
@@ -24,12 +24,38 @@
   </properties>
 
   <dependencies>
-    <!-- Jib core -->
+    <!-- Dependencies from jib-core -->
     <dependency>
-      <groupId>com.google.cloud.tools</groupId>
-      <artifactId>jib-core</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client</artifactId>
+      <version>1.23.0</version>
+      <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.15</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>23.5-jre</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.9.2</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.25</version>
+      <scope>compile</scope>
+    </dependency>
+    <!-- End dependencies from jib-core -->
 
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -133,6 +159,25 @@
 
   <build>
     <plugins>
+      <!-- Imports jib-core source -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>../jib-core/src/main/java</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <!-- Unit testing -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Sets up #44

These are forked from https://github.com/GoogleCloudPlatform/endpoints-framework-maven-plugin/tree/master/kokoro.

Also, in `jib-maven-plugin`, replaces dependency on `jib-core` with using `jib-core` as additional source set. This eliminates having to publish `jib-core` as a separate artifact.