### PR TITLE
Adds note about 'mvn clean' in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Build your container image with:
 mvn compile jib:build
 ```
 
-Subsequent builds are much faster than the initial build.
+Subsequent builds are much faster than the initial build. `mvn clean` cleans Jib's build cache and forces Jib to re-pull the base image and re-build the application layers.
 
 *Having trouble? Let us know by [submitting an issue](/../../issues/new).*
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,13 @@ Build your container image with:
 mvn compile jib:build
 ```
 
-Subsequent builds are much faster than the initial build. `mvn clean` cleans Jib's build cache and forces Jib to re-pull the base image and re-build the application layers.
+Subsequent builds are much faster than the initial build. 
+
+If you want to clear Jib's build cache and force it to re-pull the base image and re-build the application layers, run:
+
+```commandline
+mvn clean compile jib:build
+```
 
 *Having trouble? Let us know by [submitting an issue](/../../issues/new).*
 


### PR DESCRIPTION
This lets users know that if they just run `mvn clean compile jib:build` each time, they don't get the cache speed-up.