### PR TITLE
Make layer builder create reproducible layers.

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/blob/Blobs.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/blob/Blobs.java
@@ -43,9 +43,14 @@ public class Blobs {
 
   /** Writes the BLOB to a string. */
   public static String writeToString(Blob blob) throws IOException {
+    return new String(writeToByteArray(blob), StandardCharsets.UTF_8);
+  }
+
+  /** Writes the BLOB to a byte array. */
+  public static byte[] writeToByteArray(Blob blob) throws IOException {
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
     blob.writeTo(byteArrayOutputStream);
-    return new String(byteArrayOutputStream.toByteArray(), StandardCharsets.UTF_8);
+    return byteArrayOutputStream.toByteArray();
   }
 
   private Blobs() {}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildAndCacheApplicationLayersStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildAndCacheApplicationLayersStep.java
@@ -95,7 +95,9 @@ class BuildAndCacheApplicationLayersStep implements Callable<List<ListenableFutu
               return cachedLayer;
             }
 
-            LayerBuilder layerBuilder = new LayerBuilder(sourceFiles, extractionPath);
+            LayerBuilder layerBuilder =
+                new LayerBuilder(
+                    sourceFiles, extractionPath, buildConfiguration.getEnableReproducibleBuilds());
 
             cachedLayer = new CacheWriter(cache).writeLayer(layerBuilder, layerType);
             // TODO: Remove

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildConfiguration.java
@@ -49,6 +49,9 @@ public class BuildConfiguration {
     /** Known registry credentials to fallback on. */
     KNOWN_REGISTRY_CREDENTIALS(false),
 
+    /** Tell the layer build to use reproducibility features. */
+    ENABLE_REPRODUCIBLE_BUILDS(false),
+
     /** The main class to use when running the application. */
     MAIN_CLASS(true),
 
@@ -83,6 +86,7 @@ public class BuildConfiguration {
             put(Fields.TARGET_REPOSITORY, "target image name");
             put(Fields.TARGET_TAG, "target image tag");
             put(Fields.CREDENTIAL_HELPER_NAMES, "credential helper names");
+            put(Fields.ENABLE_REPRODUCIBLE_BUILDS, "enable reproducible layer builds");
             put(Fields.MAIN_CLASS, "main class");
             put(Fields.JVM_FLAGS, "JVM flags");
             put(Fields.ENVIRONMENT, "environment variables");
@@ -101,6 +105,7 @@ public class BuildConfiguration {
       values.put(Fields.KNOWN_REGISTRY_CREDENTIALS, RegistryCredentials.none());
       values.put(Fields.JVM_FLAGS, Collections.emptyList());
       values.put(Fields.ENVIRONMENT, Collections.emptyMap());
+      values.put(Fields.ENABLE_REPRODUCIBLE_BUILDS, false);
     }
 
     public Builder setBuildLogger(BuildLogger buildLogger) {
@@ -149,6 +154,11 @@ public class BuildConfiguration {
       if (knownRegistryCredentials != null) {
         values.put(Fields.KNOWN_REGISTRY_CREDENTIALS, knownRegistryCredentials);
       }
+      return this;
+    }
+
+    public Builder setEnableReproducibleBuilds(boolean enable) {
+      values.put(Fields.ENABLE_REPRODUCIBLE_BUILDS, enable);
       return this;
     }
 
@@ -260,6 +270,10 @@ public class BuildConfiguration {
 
   public List<String> getCredentialHelperNames() {
     return getFieldValue(Fields.CREDENTIAL_HELPER_NAMES);
+  }
+
+  public boolean getEnableReproducibleBuilds() {
+    return getFieldValue(Fields.ENABLE_REPRODUCIBLE_BUILDS);
   }
 
   public String getMainClass() {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/PushBlobStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/PushBlobStep.java
@@ -61,6 +61,9 @@ class PushBlobStep implements Callable<Void> {
               .setTimer(timer);
 
       if (registryClient.checkBlob(layerDigest) != null) {
+        buildConfiguration
+            .getBuildLogger()
+            .info("BLOB : " + layerDigest + " already exists on registry");
         return null;
       }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/LayerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/LayerBuilder.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 
@@ -40,9 +41,14 @@ public class LayerBuilder {
   /** The Unix-style path of the file in the partial filesystem changeset. */
   private final String extractionPath;
 
-  public LayerBuilder(List<Path> sourceFiles, String extractionPath) {
+  /** Enable reproducible features when building the tar */
+  private final boolean enableReproducibleBuilds;
+
+  public LayerBuilder(
+      List<Path> sourceFiles, String extractionPath, boolean enableReproducibleBuilds) {
     this.sourceFiles = new ArrayList<>(sourceFiles);
     this.extractionPath = extractionPath;
+    this.enableReproducibleBuilds = enableReproducibleBuilds;
   }
 
   /** Builds and returns the layer. */
@@ -72,18 +78,34 @@ public class LayerBuilder {
 
       TarArchiveEntry tarArchiveEntry =
           new TarArchiveEntry(sourceFile.toFile(), extractionPath + "/" + sourceFile.getFileName());
-      tarArchiveEntry.setModTime(0);
       filesystemEntries.add(tarArchiveEntry);
     }
 
-    TarStreamBuilder tarStreamBuilder = new TarStreamBuilder();
+    if (enableReproducibleBuilds) {
+      makeListReproducible(filesystemEntries);
+    }
 
     // Adds all the files to a tar stream.
+    TarStreamBuilder tarStreamBuilder = new TarStreamBuilder();
     for (TarArchiveEntry entry : filesystemEntries) {
       tarStreamBuilder.addEntry(entry);
     }
 
     return new UnwrittenLayer(tarStreamBuilder.toBlob());
+  }
+
+  // Sort list and strip out all non-reproducible elements from tar archive entries.
+  private void makeListReproducible(List<TarArchiveEntry> entries) {
+    entries.sort(Comparator.comparing(TarArchiveEntry::getName));
+    for (TarArchiveEntry entry : entries) {
+      if (enableReproducibleBuilds) {
+        entry.setModTime(0);
+        entry.setGroupId(0);
+        entry.setUserId(0);
+        entry.setUserName("");
+        entry.setGroupName("");
+      }
+    }
   }
 
   public List<Path> getSourceFiles() {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
@@ -39,6 +39,7 @@ public class TarStreamBuilder {
   /** Writes each entry in the filesystem to the tarball archive stream. */
   private static void writeEntriesAsTarArchive(
       List<TarArchiveEntry> entries, OutputStream tarByteStream) throws IOException {
+
     try (TarArchiveOutputStream tarArchiveOutputStream =
         new TarArchiveOutputStream(tarByteStream)) {
       // Enables PAX extended headers to support long file names.

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/BuildConfigurationTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/BuildConfigurationTest.java
@@ -37,6 +37,7 @@ public class BuildConfigurationTest {
     List<String> expectedCredentialHelperNames =
         Arrays.asList("credentialhelper", "anotherCredentialHelper");
     String expectedMainClass = "mainclass";
+    boolean expectedEnableReproducibleBuilds = true;
     List<String> expectedJvmFlags = Arrays.asList("some", "jvm", "flags");
 
     BuildConfiguration buildConfiguration =
@@ -50,6 +51,7 @@ public class BuildConfigurationTest {
             .setCredentialHelperNames(expectedCredentialHelperNames)
             .setMainClass(expectedMainClass)
             .setJvmFlags(expectedJvmFlags)
+            .setEnableReproducibleBuilds(true)
             .build();
     Assert.assertEquals(expectedBaseImageServerUrl, buildConfiguration.getBaseImageRegistry());
     Assert.assertEquals(expectedBaseImageName, buildConfiguration.getBaseImageRepository());
@@ -61,6 +63,8 @@ public class BuildConfigurationTest {
         expectedCredentialHelperNames, buildConfiguration.getCredentialHelperNames());
     Assert.assertEquals(expectedMainClass, buildConfiguration.getMainClass());
     Assert.assertEquals(expectedJvmFlags, buildConfiguration.getJvmFlags());
+    Assert.assertEquals(
+        expectedEnableReproducibleBuilds, buildConfiguration.getEnableReproducibleBuilds());
   }
 
   @Test


### PR DESCRIPTION
- Strip out non-reproducible properties from tarArchiveEntry.
- Allow the user to toggle this feature through build config.

This is a first run, there still some work to do. Decisions in this PR made but I'm not sure about:
- default for reproducibility = false
- reproducibility is configurable. 
- the defaults for file permission overwrites (as described in #7)