### PR TITLE
Jib builds Java Docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## What is Jib?
 
-Jib is a Maven plugin for building container images for your Java applications.
+Jib is a Maven plugin for building Docker<!-- and OCI--> images for your Java applications.
 
 ## Goals
 


### PR DESCRIPTION
Adds `Docker` as explicit image format. Will uncomment `and OCI` once OCI image building is supported. This should help people looking for building Docker images to more easily find Jib.