### PR TITLE
Renames DockerCredentialRetriever to DockerCredentialHelper.

### DIFF
--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelperIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelperIntegrationTest.java
@@ -27,8 +27,8 @@ import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
 
-/** Integration tests for {@link DockerCredentialRetriever}. */
-public class DockerCredentialRetrieverIntegrationTest {
+/** Integration tests for {@link DockerCredentialHelper}. */
+public class DockerCredentialHelperIntegrationTest {
 
   /** Tests retrieval via {@code docker-credential-gcr} CLI. */
   @Test
@@ -43,10 +43,10 @@ public class DockerCredentialRetrieverIntegrationTest {
     }
     process.waitFor();
 
-    DockerCredentialRetriever dockerCredentialRetriever =
-        new DockerCredentialRetrieverFactory("myregistry").withSuffix("gcr");
+    DockerCredentialHelper dockerCredentialHelper =
+        new DockerCredentialHelperFactory("myregistry").withCredentialHelperSuffix("gcr");
 
-    Authorization authorization = dockerCredentialRetriever.retrieve();
+    Authorization authorization = dockerCredentialHelper.retrieve();
 
     // Checks that token received was base64 encoding of "myusername:mysecret".
     Assert.assertEquals("bXl1c2VybmFtZTpteXNlY3JldA==", authorization.getToken());
@@ -56,10 +56,10 @@ public class DockerCredentialRetrieverIntegrationTest {
   public void testRetrieve_nonexistentCredentialHelper()
       throws IOException, NonexistentServerUrlDockerCredentialHelperException {
     try {
-      DockerCredentialRetriever fakeDockerCredentialRetriever =
-          new DockerCredentialRetrieverFactory("").withSuffix("fake-cloud-provider");
+      DockerCredentialHelper fakeDockerCredentialHelper =
+          new DockerCredentialHelperFactory("").withCredentialHelperSuffix("fake-cloud-provider");
 
-      fakeDockerCredentialRetriever.retrieve();
+      fakeDockerCredentialHelper.retrieve();
 
       Assert.fail("Retrieve should have failed for nonexistent credential helper");
 
@@ -73,10 +73,10 @@ public class DockerCredentialRetrieverIntegrationTest {
   public void testRetrieve_nonexistentServerUrl()
       throws IOException, NonexistentDockerCredentialHelperException {
     try {
-      DockerCredentialRetriever fakeDockerCredentialRetriever =
-          new DockerCredentialRetrieverFactory("fake.server.url").withSuffix("gcr");
+      DockerCredentialHelper fakeDockerCredentialHelper =
+          new DockerCredentialHelperFactory("fake.server.url").withCredentialHelperSuffix("gcr");
 
-      fakeDockerCredentialRetriever.retrieve();
+      fakeDockerCredentialHelper.retrieve();
 
       Assert.fail("Retrieve should have failed for nonexistent server URL");
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/RetrieveRegistryCredentialsStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/RetrieveRegistryCredentialsStep.java
@@ -19,7 +19,7 @@ package com.google.cloud.tools.jib.builder;
 import com.google.cloud.tools.jib.Timer;
 import com.google.cloud.tools.jib.http.Authorization;
 import com.google.cloud.tools.jib.registry.credentials.DockerConfigCredentialRetriever;
-import com.google.cloud.tools.jib.registry.credentials.DockerCredentialRetrieverFactory;
+import com.google.cloud.tools.jib.registry.credentials.DockerCredentialHelperFactory;
 import com.google.cloud.tools.jib.registry.credentials.NonexistentDockerCredentialHelperException;
 import com.google.cloud.tools.jib.registry.credentials.NonexistentServerUrlDockerCredentialHelperException;
 import com.google.common.annotations.VisibleForTesting;
@@ -42,14 +42,14 @@ class RetrieveRegistryCredentialsStep implements Callable<Authorization> {
 
   private final BuildConfiguration buildConfiguration;
   private final String registry;
-  private final DockerCredentialRetrieverFactory dockerCredentialRetrieverFactory;
+  private final DockerCredentialHelperFactory dockerCredentialHelperFactory;
   private final DockerConfigCredentialRetriever dockerConfigCredentialRetriever;
 
   RetrieveRegistryCredentialsStep(BuildConfiguration buildConfiguration, String registry) {
     this(
         buildConfiguration,
         registry,
-        new DockerCredentialRetrieverFactory(registry),
+        new DockerCredentialHelperFactory(registry),
         new DockerConfigCredentialRetriever(registry));
   }
 
@@ -57,11 +57,11 @@ class RetrieveRegistryCredentialsStep implements Callable<Authorization> {
   RetrieveRegistryCredentialsStep(
       BuildConfiguration buildConfiguration,
       String registry,
-      DockerCredentialRetrieverFactory dockerCredentialRetrieverFactory,
+      DockerCredentialHelperFactory dockerCredentialHelperFactory,
       DockerConfigCredentialRetriever dockerConfigCredentialRetriever) {
     this.buildConfiguration = buildConfiguration;
     this.registry = registry;
-    this.dockerCredentialRetrieverFactory = dockerCredentialRetrieverFactory;
+    this.dockerCredentialHelperFactory = dockerCredentialHelperFactory;
     this.dockerConfigCredentialRetriever = dockerConfigCredentialRetriever;
   }
 
@@ -134,7 +134,9 @@ class RetrieveRegistryCredentialsStep implements Callable<Authorization> {
       throws NonexistentDockerCredentialHelperException, IOException {
     try {
       Authorization authorization =
-          dockerCredentialRetrieverFactory.withSuffix(credentialHelperSuffix).retrieve();
+          dockerCredentialHelperFactory
+              .withCredentialHelperSuffix(credentialHelperSuffix)
+              .retrieve();
       logGotCredentialsFrom("docker-credential-" + credentialHelperSuffix);
       return authorization;
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetriever.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetriever.java
@@ -52,7 +52,7 @@ public class DockerConfigCredentialRetriever {
 
   private final String registry;
   private final Path dockerConfigFile;
-  private final DockerCredentialRetrieverFactory dockerCredentialRetrieverFactory;
+  private final DockerCredentialHelperFactory dockerCredentialHelperFactory;
 
   public DockerConfigCredentialRetriever(String registry) {
     this(registry, DOCKER_CONFIG_FILE);
@@ -62,17 +62,17 @@ public class DockerConfigCredentialRetriever {
   DockerConfigCredentialRetriever(String registry, Path dockerConfigFile) {
     this.registry = registry;
     this.dockerConfigFile = dockerConfigFile;
-    this.dockerCredentialRetrieverFactory = new DockerCredentialRetrieverFactory(registry);
+    this.dockerCredentialHelperFactory = new DockerCredentialHelperFactory(registry);
   }
 
   @VisibleForTesting
   DockerConfigCredentialRetriever(
       String registry,
       Path dockerConfigFile,
-      DockerCredentialRetrieverFactory dockerCredentialRetrieverFactory) {
+      DockerCredentialHelperFactory dockerCredentialHelperFactory) {
     this.registry = registry;
     this.dockerConfigFile = dockerConfigFile;
-    this.dockerCredentialRetrieverFactory = dockerCredentialRetrieverFactory;
+    this.dockerCredentialHelperFactory = dockerCredentialHelperFactory;
   }
 
   /** @return {@link Authorization} found for {@code registry}, or {@code null} if not found */
@@ -91,7 +91,9 @@ public class DockerConfigCredentialRetriever {
     String credentialHelperSuffix = dockerConfigTemplate.getCredentialHelperFor(registry);
     if (credentialHelperSuffix != null) {
       try {
-        return dockerCredentialRetrieverFactory.withSuffix(credentialHelperSuffix).retrieve();
+        return dockerCredentialHelperFactory
+            .withCredentialHelperSuffix(credentialHelperSuffix)
+            .retrieve();
 
       } catch (IOException
           | NonexistentServerUrlDockerCredentialHelperException

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelper.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelper.java
@@ -33,7 +33,7 @@ import java.nio.charset.StandardCharsets;
  * @see <a
  *     href="https://github.com/docker/docker-credential-helpers">https://github.com/docker/docker-credential-helpers</a>
  */
-public class DockerCredentialRetriever {
+public class DockerCredentialHelper {
 
   private final String serverUrl;
   private final String credentialHelperSuffix;
@@ -47,12 +47,12 @@ public class DockerCredentialRetriever {
   }
 
   /**
-   * Construct with {@link DockerCredentialRetrieverFactory}.
+   * Construct with {@link DockerCredentialHelperFactory}.
    *
    * @param serverUrl the server URL to pass into the credential helper
    * @param credentialHelperSuffix the credential helper CLI suffix
    */
-  DockerCredentialRetriever(String serverUrl, String credentialHelperSuffix) {
+  DockerCredentialHelper(String serverUrl, String credentialHelperSuffix) {
     this.serverUrl = serverUrl;
     this.credentialHelperSuffix = credentialHelperSuffix;
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelperFactory.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelperFactory.java
@@ -16,16 +16,20 @@
 
 package com.google.cloud.tools.jib.registry.credentials;
 
-/** Factory class for constructing {@link DockerCredentialRetriever}. */
-public class DockerCredentialRetrieverFactory {
+/** Factory class for constructing {@link DockerCredentialHelper}. */
+public class DockerCredentialHelperFactory {
 
   private final String registry;
 
-  public DockerCredentialRetrieverFactory(String registry) {
+  public DockerCredentialHelperFactory(String registry) {
     this.registry = registry;
   }
 
-  public DockerCredentialRetriever withSuffix(String credentialHelperSuffix) {
-    return new DockerCredentialRetriever(registry, credentialHelperSuffix);
+  /**
+   * @return a {@link DockerCredentialHelper} that uses the {@code
+   *     docker-credential-[credentialHelperSuffix]} command
+   */
+  public DockerCredentialHelper withCredentialHelperSuffix(String credentialHelperSuffix) {
+    return new DockerCredentialHelper(registry, credentialHelperSuffix);
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/RegistryCredentials.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/RegistryCredentials.java
@@ -62,7 +62,7 @@ public class RegistryCredentials {
           registryCredentials.store(
               registry,
               "docker-credential-" + credentialHelperSuffix,
-              new DockerCredentialRetriever(registry, credentialHelperSuffix).retrieve());
+              new DockerCredentialHelper(registry, credentialHelperSuffix).retrieve());
 
         } catch (NonexistentServerUrlDockerCredentialHelperException ex) {
           // No authorization is found, so continues on to the next credential helper.

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetrieverTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetrieverTest.java
@@ -35,9 +35,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class DockerConfigCredentialRetrieverTest {
 
   @Mock private Authorization mockAuthorization;
-  @Mock private DockerCredentialRetriever mockDockerCredentialRetriever;
+  @Mock private DockerCredentialHelper mockDockerCredentialHelper;
 
-  @Mock private DockerCredentialRetrieverFactory mockDockerCredentialRetrieverFactory;
+  @Mock private DockerCredentialHelperFactory mockDockerCredentialHelperFactory;
 
   private Path dockerConfigFile;
 
@@ -47,7 +47,7 @@ public class DockerConfigCredentialRetrieverTest {
           NonexistentDockerCredentialHelperException, IOException {
     dockerConfigFile = Paths.get(Resources.getResource("json/dockerconfig.json").toURI());
 
-    Mockito.when(mockDockerCredentialRetriever.retrieve()).thenReturn(mockAuthorization);
+    Mockito.when(mockDockerCredentialHelper.retrieve()).thenReturn(mockAuthorization);
   }
 
   @Test
@@ -70,12 +70,13 @@ public class DockerConfigCredentialRetrieverTest {
 
   @Test
   public void testRetrieve_useCredsStore() {
-    Mockito.when(mockDockerCredentialRetrieverFactory.withSuffix("some credential store"))
-        .thenReturn(mockDockerCredentialRetriever);
+    Mockito.when(
+            mockDockerCredentialHelperFactory.withCredentialHelperSuffix("some credential store"))
+        .thenReturn(mockDockerCredentialHelper);
 
     DockerConfigCredentialRetriever dockerConfigCredentialRetriever =
         new DockerConfigCredentialRetriever(
-            "just registry", dockerConfigFile, mockDockerCredentialRetrieverFactory);
+            "just registry", dockerConfigFile, mockDockerCredentialHelperFactory);
 
     Authorization authorization = dockerConfigCredentialRetriever.retrieve();
     Assert.assertNotNull(authorization);
@@ -84,12 +85,14 @@ public class DockerConfigCredentialRetrieverTest {
 
   @Test
   public void testRetrieve_useCredHelper() {
-    Mockito.when(mockDockerCredentialRetrieverFactory.withSuffix("another credential helper"))
-        .thenReturn(mockDockerCredentialRetriever);
+    Mockito.when(
+            mockDockerCredentialHelperFactory.withCredentialHelperSuffix(
+                "another credential helper"))
+        .thenReturn(mockDockerCredentialHelper);
 
     DockerConfigCredentialRetriever dockerConfigCredentialRetriever =
         new DockerConfigCredentialRetriever(
-            "another registry", dockerConfigFile, mockDockerCredentialRetrieverFactory);
+            "another registry", dockerConfigFile, mockDockerCredentialHelperFactory);
 
     Authorization authorization = dockerConfigCredentialRetriever.retrieve();
     Assert.assertNotNull(authorization);


### PR DESCRIPTION
Just refactoring `DockerCredentialRetriever` to `DockerCredentialHelper` (and `DockerCredentialRetrieverFactory` to `DockerCredentialHelperFactory`).