### PR TITLE
Adds configuration for building and pushing as OCI image format.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+## 0.1.3
+### Added
+- Build and push OCI container image ([#96](https://github.com/google/jib/issues/96))
+
 ## 0.1.2
 ### Added
 - Use credentials from Docker config if none can be found otherwise ([#101](https://github.com/google/jib/issues/101))

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Field | Default | Description
 `jvmFlags`|*None*|Additional flags to pass into the JVM when running your application.
 `mainClass`|Uses `mainClass` from `maven-jar-plugin`|The main class to launch the application from.
 `enableReproducibleBuilds`|`true`|Building with the same application contents always generates the same image. Note that this does *not* preserve file timestamps and ownership. 
+<!--`imageFormat`|`Docker`|Use `OCI` to build an [OCI container image](https://www.opencontainers.org/).-->
 
 ### Example
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildConfiguration.java
@@ -18,7 +18,6 @@ package com.google.cloud.tools.jib.builder;
 
 import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
-import com.google.cloud.tools.jib.image.json.OCIManifestTemplate;
 import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
 import com.google.cloud.tools.jib.registry.credentials.RegistryCredentials;
 import java.util.ArrayList;
@@ -33,9 +32,8 @@ public class BuildConfiguration {
 
   public static class Builder {
 
-    /** All the parameters set to their default values. */
+    // All the parameters below are set to their default values.
     private ImageReference baseImageReference;
-
     private ImageReference targetImageReference;
     private List<String> credentialHelperNames = new ArrayList<>();
     private RegistryCredentials knownRegistryCredentials = RegistryCredentials.none();
@@ -100,20 +98,8 @@ public class BuildConfiguration {
       return this;
     }
 
-    /**
-     * Use {@code Docker} for {@link V22ManifestTemplate}. Use {@code OCI} for {@link
-     * OCIManifestTemplate}.
-     */
-    public Builder setTargetFormat(String format) {
-      if ("Docker".equals(format)) {
-        targetFormat = V22ManifestTemplate.class;
-
-      } else if ("OCI".equals(format)) {
-        targetFormat = OCIManifestTemplate.class;
-
-      } else {
-        throw new IllegalArgumentException(format + " is not an acceptable target format");
-      }
+    public Builder setTargetFormat(Class<? extends BuildableManifestTemplate> targetFormat) {
+      this.targetFormat = targetFormat;
       return this;
     }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/PushImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/PushImageStep.java
@@ -23,8 +23,8 @@ import com.google.cloud.tools.jib.http.Authorization;
 import com.google.cloud.tools.jib.image.DuplicateLayerException;
 import com.google.cloud.tools.jib.image.Image;
 import com.google.cloud.tools.jib.image.LayerPropertyNotFoundException;
+import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
 import com.google.cloud.tools.jib.image.json.ImageToJsonTranslator;
-import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
 import com.google.cloud.tools.jib.registry.RegistryClient;
 import com.google.cloud.tools.jib.registry.RegistryException;
 import com.google.common.util.concurrent.Futures;
@@ -120,9 +120,9 @@ class PushImageStep implements Callable<Void> {
       ImageToJsonTranslator imageToJsonTranslator = new ImageToJsonTranslator(image);
 
       // Pushes the image manifest.
-      V22ManifestTemplate manifestTemplate =
+      BuildableManifestTemplate manifestTemplate =
           imageToJsonTranslator.getManifestTemplate(
-              V22ManifestTemplate.class,
+              buildConfiguration.getTargetFormat(),
               NonBlockingFutures.get(
                   NonBlockingFutures.get(containerConfigurationBlobDescriptorFutureFuture)));
       registryClient.pushManifest(manifestTemplate, buildConfiguration.getTargetTag());

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/RegistryCredentials.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/RegistryCredentials.java
@@ -30,9 +30,11 @@ import javax.annotation.Nullable;
  */
 public class RegistryCredentials {
 
+  private static final RegistryCredentials EMPTY = new RegistryCredentials();
+
   /** Instantiates with no credentials. */
   public static RegistryCredentials none() {
-    return new RegistryCredentials();
+    return EMPTY;
   }
 
   /** Instantiates with credentials for a single registry. */
@@ -109,14 +111,8 @@ public class RegistryCredentials {
   /** Maps from registry to the credentials for that registry. */
   private final Map<String, AuthorizationSourcePair> credentials = new HashMap<>();
 
-  /** Instantiate using {@link #from}. */
+  /** Instantiate using {@link #from}. Immutable after instantiation. */
   private RegistryCredentials() {};
-
-  private RegistryCredentials store(
-      String registry, String credentialSource, Authorization authorization) {
-    credentials.put(registry, new AuthorizationSourcePair(credentialSource, authorization));
-    return this;
-  }
 
   /** @return {@code true} if there are credentials for {@code registry}; {@code false} otherwise */
   public boolean has(String registry) {
@@ -145,5 +141,12 @@ public class RegistryCredentials {
       return null;
     }
     return credentials.get(registry).credentialSource;
+  }
+
+  /** Only to be called in static initializers. */
+  private RegistryCredentials store(
+      String registry, String credentialSource, Authorization authorization) {
+    credentials.put(registry, new AuthorizationSourcePair(credentialSource, authorization));
+    return this;
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/BuildConfigurationTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/BuildConfigurationTest.java
@@ -17,9 +17,13 @@
 package com.google.cloud.tools.jib.builder;
 
 import com.google.cloud.tools.jib.image.ImageReference;
+import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
+import com.google.cloud.tools.jib.image.json.OCIManifestTemplate;
+import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
 import com.google.cloud.tools.jib.registry.credentials.RegistryCredentials;
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.junit.Assert;
@@ -40,11 +44,12 @@ public class BuildConfigurationTest {
         Arrays.asList("credentialhelper", "anotherCredentialHelper");
     String expectedMainClass = "mainclass";
     RegistryCredentials expectedKnownRegistryCredentials = Mockito.mock(RegistryCredentials.class);
-    boolean expectedEnableReproducibleBuilds = true;
+    boolean expectedEnableReproducibleBuilds = false;
     List<String> expectedJvmFlags = Arrays.asList("some", "jvm", "flags");
     Map<String, String> expectedEnvironment = ImmutableMap.of("key", "value");
+    Class<? extends BuildableManifestTemplate> expectedTargetFormat = OCIManifestTemplate.class;
 
-    BuildConfiguration buildConfiguration =
+    BuildConfiguration.Builder buildConfigurationBuilder =
         BuildConfiguration.builder(Mockito.mock(BuildLogger.class))
             .setBaseImage(
                 ImageReference.of(
@@ -54,11 +59,13 @@ public class BuildConfigurationTest {
                     expectedTargetServerUrl, expectedTargetImageName, expectedTargetTag))
             .setCredentialHelperNames(expectedCredentialHelperNames)
             .setKnownRegistryCredentials(expectedKnownRegistryCredentials)
-            .setEnableReproducibleBuilds(true)
+            .setEnableReproducibleBuilds(expectedEnableReproducibleBuilds)
             .setMainClass(expectedMainClass)
             .setJvmFlags(expectedJvmFlags)
             .setEnvironment(expectedEnvironment)
-            .build();
+            .setTargetFormat("OCI");
+    BuildConfiguration buildConfiguration = buildConfigurationBuilder.build();
+
     Assert.assertEquals(expectedBaseImageServerUrl, buildConfiguration.getBaseImageRegistry());
     Assert.assertEquals(expectedBaseImageName, buildConfiguration.getBaseImageRepository());
     Assert.assertEquals(expectedBaseImageTag, buildConfiguration.getBaseImageTag());
@@ -74,6 +81,38 @@ public class BuildConfigurationTest {
     Assert.assertEquals(expectedMainClass, buildConfiguration.getMainClass());
     Assert.assertEquals(expectedJvmFlags, buildConfiguration.getJvmFlags());
     Assert.assertEquals(expectedEnvironment, buildConfiguration.getEnvironment());
+    Assert.assertEquals(expectedTargetFormat, buildConfiguration.getTargetFormat());
+  }
+
+  @Test
+  public void testBuilder_default() {
+    // These are required and don't have defaults.
+    String expectedBaseImageServerUrl = "someserver";
+    String expectedBaseImageName = "baseimage";
+    String expectedBaseImageTag = "baseimagetag";
+    String expectedTargetServerUrl = "someotherserver";
+    String expectedTargetImageName = "targetimage";
+    String expectedTargetTag = "targettag";
+    String expectedMainClass = "mainclass";
+
+    BuildConfiguration buildConfiguration =
+        BuildConfiguration.builder(Mockito.mock(BuildLogger.class))
+            .setBaseImage(
+                ImageReference.of(
+                    expectedBaseImageServerUrl, expectedBaseImageName, expectedBaseImageTag))
+            .setTargetImage(
+                ImageReference.of(
+                    expectedTargetServerUrl, expectedTargetImageName, expectedTargetTag))
+            .setMainClass(expectedMainClass)
+            .build();
+
+    Assert.assertEquals(Collections.emptyList(), buildConfiguration.getCredentialHelperNames());
+    Assert.assertEquals(
+        RegistryCredentials.none(), buildConfiguration.getKnownRegistryCredentials());
+    Assert.assertTrue(buildConfiguration.getEnableReproducibleBuilds());
+    Assert.assertEquals(Collections.emptyList(), buildConfiguration.getJvmFlags());
+    Assert.assertEquals(Collections.emptyMap(), buildConfiguration.getEnvironment());
+    Assert.assertEquals(V22ManifestTemplate.class, buildConfiguration.getTargetFormat());
   }
 
   @Test

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/BuildConfigurationTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/BuildConfigurationTest.java
@@ -63,7 +63,7 @@ public class BuildConfigurationTest {
             .setMainClass(expectedMainClass)
             .setJvmFlags(expectedJvmFlags)
             .setEnvironment(expectedEnvironment)
-            .setTargetFormat("OCI");
+            .setTargetFormat(OCIManifestTemplate.class);
     BuildConfiguration buildConfiguration = buildConfigurationBuilder.build();
 
     Assert.assertEquals(expectedBaseImageServerUrl, buildConfiguration.getBaseImageRegistry());

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -26,6 +26,9 @@ import com.google.cloud.tools.jib.http.Authorization;
 import com.google.cloud.tools.jib.http.Authorizations;
 import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
+import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
+import com.google.cloud.tools.jib.image.json.OCIManifestTemplate;
+import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
 import com.google.cloud.tools.jib.registry.RegistryAuthenticationFailedException;
 import com.google.cloud.tools.jib.registry.RegistryClient;
 import com.google.cloud.tools.jib.registry.RegistryUnauthorizedException;
@@ -56,6 +59,22 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 /** Builds a container image. */
 @Mojo(name = "build", requiresDependencyResolution = ResolutionScope.RUNTIME_PLUS_SYSTEM)
 public class BuildImageMojo extends AbstractMojo {
+
+  /** Enumeration of {@link BuildableManifestTemplate}s. */
+  public enum ImageFormat {
+    Docker(V22ManifestTemplate.class),
+    OCI(OCIManifestTemplate.class);
+
+    private final Class<? extends BuildableManifestTemplate> manifestTemplateClass;
+
+    ImageFormat(Class<? extends BuildableManifestTemplate> manifestTemplateClass) {
+      this.manifestTemplateClass = manifestTemplateClass;
+    }
+
+    private Class<? extends BuildableManifestTemplate> getManifestTemplateClass() {
+      return manifestTemplateClass;
+    }
+  }
 
   /** Directory name for the cache. The directory will be relative to the build output directory. */
   private static final String CACHE_DIRECTORY_NAME = "jib-cache";
@@ -91,7 +110,7 @@ public class BuildImageMojo extends AbstractMojo {
   private boolean enableReproducibleBuilds;
 
   @Parameter(defaultValue = "Docker", required = true)
-  private String imageFormat;
+  private ImageFormat imageFormat;
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
@@ -144,7 +163,7 @@ public class BuildImageMojo extends AbstractMojo {
             .setEnableReproducibleBuilds(enableReproducibleBuilds)
             .setJvmFlags(jvmFlags)
             .setEnvironment(environment)
-            .setTargetFormat(imageFormat)
+            .setTargetFormat(imageFormat.getManifestTemplateClass())
             .build();
 
     // Uses a directory in the Maven build cache as the Jib cache.

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -90,6 +90,9 @@ public class BuildImageMojo extends AbstractMojo {
   @Parameter(defaultValue = "true", required = true)
   private boolean enableReproducibleBuilds;
 
+  @Parameter(defaultValue = "Docker", required = true)
+  private String imageFormat;
+
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
     validateParameters();
@@ -141,6 +144,7 @@ public class BuildImageMojo extends AbstractMojo {
             .setEnableReproducibleBuilds(enableReproducibleBuilds)
             .setJvmFlags(jvmFlags)
             .setEnvironment(environment)
+            .setTargetFormat(imageFormat)
             .build();
 
     // Uses a directory in the Maven build cache as the Jib cache.


### PR DESCRIPTION
Fixes #96 

The `jib-maven-plugin` configuration is called `imageFormat` and can take `Docker` (default) or `OCI`.