### PR TITLE
Separates presubmit from continuous build scripts.

### DIFF
--- a/kokoro/presubmit.bat
+++ b/kokoro/presubmit.bat
@@ -1,0 +1,16 @@
+@echo on
+
+REM Java 9 does not work with Mockito mockmaker.
+set JAVA_HOME=c:\program files\java\jdk1.8.0_152
+set PATH=%JAVA_HOME%\bin;%PATH%
+
+cd github/jib
+
+REM Stops any left-over containers.
+REM FOR /f "tokens=*" %%i IN ('docker ps -q') DO docker rm -vf %%i
+
+REM TODO: Enable integration tests once docker works (b/73345382).
+cd jib-core && call gradlew.bat clean build publishToMavenLocal --info && ^
+cd ../jib-maven-plugin && call mvnw.cmd clean install cobertura:cobertura -B -U -X
+
+exit /b %ERRORLEVEL%

--- a/kokoro/presubmit.sh
+++ b/kokoro/presubmit.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+set -x
+
+gcloud components install docker-credential-gcr
+export PATH=$PATH:/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin/
+
+# Stops any left-over containers.
+docker stop $(docker container ls --quiet) || true
+
+cd github/jib
+
+(cd jib-core; ./gradlew clean build integrationTest publishToMavenLocal --info)
+(cd jib-maven-plugin; ./mvnw clean install cobertura:cobertura -B -U -X)


### PR DESCRIPTION
Part of #11 .

The scripts are the same currently.

Next step is to enable integration testing for `jib-maven-plugin` in the continuous scripts.