### PR TITLE
Removes cobertura from build scripts.

### DIFF
--- a/kokoro/continuous.bat
+++ b/kokoro/continuous.bat
@@ -11,6 +11,6 @@ REM FOR /f "tokens=*" %%i IN ('docker ps -q') DO docker rm -vf %%i
 
 REM TODO: Enable integration tests once docker works (b/73345382).
 cd jib-core && call gradlew.bat clean build publishToMavenLocal --info && ^
-cd ../jib-maven-plugin && call mvnw.cmd clean install cobertura:cobertura -B -U -X
+cd ../jib-maven-plugin && call mvnw.cmd clean install -B -U -X
 
 exit /b %ERRORLEVEL%

--- a/kokoro/continuous.sh
+++ b/kokoro/continuous.sh
@@ -12,4 +12,4 @@ docker stop $(docker container ls --quiet) || true
 cd github/jib
 
 (cd jib-core; ./gradlew clean build integrationTest publishToMavenLocal --info)
-(cd jib-maven-plugin; ./mvnw clean install cobertura:cobertura -B -U -X)
+(cd jib-maven-plugin; ./mvnw clean install -B -U -X)

--- a/kokoro/presubmit.bat
+++ b/kokoro/presubmit.bat
@@ -11,6 +11,6 @@ REM FOR /f "tokens=*" %%i IN ('docker ps -q') DO docker rm -vf %%i
 
 REM TODO: Enable integration tests once docker works (b/73345382).
 cd jib-core && call gradlew.bat clean build publishToMavenLocal --info && ^
-cd ../jib-maven-plugin && call mvnw.cmd clean install cobertura:cobertura -B -U -X
+cd ../jib-maven-plugin && call mvnw.cmd clean install -B -U -X
 
 exit /b %ERRORLEVEL%

--- a/kokoro/presubmit.sh
+++ b/kokoro/presubmit.sh
@@ -12,4 +12,4 @@ docker stop $(docker container ls --quiet) || true
 cd github/jib
 
 (cd jib-core; ./gradlew clean build integrationTest publishToMavenLocal --info)
-(cd jib-maven-plugin; ./mvnw clean install cobertura:cobertura -B -U -X)
+(cd jib-maven-plugin; ./mvnw clean install -B -U -X)


### PR DESCRIPTION
We are not using it and it is doesn't recognize java 8 constructs.