### PR TITLE
Fixes DockerfileTemplate resource resolution.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 ### Fixed
+- jib:dockercontext not generating Dockerfile
 - Null tag validation generating NullPointerException ([#125](https://github.com/google/jib/issues/125))
 - Build failure on project with no dependencies ([#126](https://github.com/google/jib/issues/126))
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/DockerContextMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/DockerContextMojo.java
@@ -21,10 +21,10 @@ import com.google.cloud.tools.jib.builder.SourceFilesConfiguration;
 import com.google.cloud.tools.jib.filesystem.DirectoryWalker;
 import com.google.cloud.tools.jib.filesystem.PathConsumer;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.io.InsecureRecursiveDeleteException;
 import com.google.common.io.MoreFiles;
 import com.google.common.io.Resources;
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -130,22 +130,17 @@ public class DockerContextMojo extends AbstractMojo {
 
   @VisibleForTesting
   /** Makes a {@code Dockerfile} from the {@code DockerfileTemplate}. */
-  String makeDockerfile(SourceFilesConfiguration sourceFilesConfiguration)
-      throws IOException, URISyntaxException {
-    Path dockerfileTemplate = Paths.get(Resources.getResource("DockerfileTemplate").toURI());
+  String makeDockerfile(SourceFilesConfiguration sourceFilesConfiguration) throws IOException {
+    String dockerfileTemplate =
+        Resources.toString(Resources.getResource("DockerfileTemplate"), StandardCharsets.UTF_8);
 
-    String dockerfile = new String(Files.readAllBytes(dockerfileTemplate), StandardCharsets.UTF_8);
-    dockerfile =
-        dockerfile
-            .replace("@@BASE_IMAGE@@", from)
-            .replace(
-                "@@DEPENDENCIES_PATH_ON_IMAGE@@",
-                sourceFilesConfiguration.getDependenciesPathOnImage())
-            .replace(
-                "@@RESOURCES_PATH_ON_IMAGE@@", sourceFilesConfiguration.getResourcesPathOnImage())
-            .replace("@@CLASSES_PATH_ON_IMAGE@@", sourceFilesConfiguration.getClassesPathOnImage())
-            .replace("@@ENTRYPOINT@@", getEntrypoint(sourceFilesConfiguration));
-    return dockerfile;
+    return dockerfileTemplate
+        .replace("@@BASE_IMAGE@@", from)
+        .replace(
+            "@@DEPENDENCIES_PATH_ON_IMAGE@@", sourceFilesConfiguration.getDependenciesPathOnImage())
+        .replace("@@RESOURCES_PATH_ON_IMAGE@@", sourceFilesConfiguration.getResourcesPathOnImage())
+        .replace("@@CLASSES_PATH_ON_IMAGE@@", sourceFilesConfiguration.getClassesPathOnImage())
+        .replace("@@ENTRYPOINT@@", getEntrypoint(sourceFilesConfiguration));
   }
 
   /**
@@ -214,11 +209,15 @@ public class DockerContextMojo extends AbstractMojo {
 
       projectProperties.getLog().info("Created Docker context at " + targetDir);
 
+    } catch (InsecureRecursiveDeleteException ex) {
+      throwMojoExecutionExceptionWithHelpMessage(
+          ex,
+          "cannot clear directory '"
+              + targetDir
+              + "' safely - clear it manually before creating the Docker context");
+
     } catch (IOException ex) {
       throwMojoExecutionExceptionWithHelpMessage(ex, "check if `targetDir` is set correctly");
-
-    } catch (URISyntaxException ex) {
-      throw new MojoFailureException("Unexpected URISyntaxException", ex);
     }
   }
 


### PR DESCRIPTION
`Paths.get(Resources.get("...").toURI())` fails with `FileSystemNotFoundException`. Rather, it should use `Resources.toString`.