### PR TITLE
 Fixes parsing Docker config JSON with extra fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - `jib:dockercontext` not building a `Dockerfile` ([#171](https://github.com/google/jib/pull/171))
+- Failure to parse Docker config with `HttpHeaders` field ([]())
 
 ## 0.1.5
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - `jib:dockercontext` not building a `Dockerfile` ([#171](https://github.com/google/jib/pull/171))
-- Failure to parse Docker config with `HttpHeaders` field ([]())
+- Failure to parse Docker config with `HttpHeaders` field ([#175](https://github.com/google/jib/pull/175))
 
 ## 0.1.5
 ### Added

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/RetrieveRegistryCredentialsStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/RetrieveRegistryCredentialsStep.java
@@ -89,12 +89,17 @@ class RetrieveRegistryCredentialsStep implements Callable<Authorization> {
       }
 
       // Tries to get registry credentials from the Docker config.
-      Authorization dockerConfigAuthorization = dockerConfigCredentialRetriever.retrieve();
-      if (dockerConfigAuthorization != null) {
-        buildConfiguration
-            .getBuildLogger()
-            .info("Using credentials from Docker config for " + registry);
-        return dockerConfigAuthorization;
+      try {
+        Authorization dockerConfigAuthorization = dockerConfigCredentialRetriever.retrieve();
+        if (dockerConfigAuthorization != null) {
+          buildConfiguration
+              .getBuildLogger()
+              .info("Using credentials from Docker config for " + registry);
+          return dockerConfigAuthorization;
+        }
+
+      } catch (IOException ex) {
+        buildConfiguration.getBuildLogger().info("Unable to parse Docker config");
       }
 
       // Tries to infer common credential helpers for known registries.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetriever.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetriever.java
@@ -75,19 +75,24 @@ public class DockerConfigCredentialRetriever {
     this.dockerCredentialHelperFactory = dockerCredentialHelperFactory;
   }
 
-  /** @return {@link Authorization} found for {@code registry}, or {@code null} if not found */
+  /**
+   * @return {@link Authorization} found for {@code registry}, or {@code null} if not found
+   * @throws IOException if failed to parse the config JSON
+   */
   @Nullable
-  public Authorization retrieve() {
+  public Authorization retrieve() throws IOException {
     DockerConfigTemplate dockerConfigTemplate = loadDockerConfigTemplate();
     if (dockerConfigTemplate == null) {
       return null;
     }
 
+    // First, tries to find defined auth.
     String auth = dockerConfigTemplate.getAuthFor(registry);
     if (auth != null) {
       return Authorizations.withBasicToken(auth);
     }
 
+    // Then, tries to use a defined credHelpers credential helper.
     String credentialHelperSuffix = dockerConfigTemplate.getCredentialHelperFor(registry);
     if (credentialHelperSuffix != null) {
       try {
@@ -105,19 +110,18 @@ public class DockerConfigCredentialRetriever {
     return null;
   }
 
-  /** Loads the Docker config JSON and caches it. */
+  /**
+   * Loads the Docker config JSON and caches it.
+   *
+   * @throws IOException if failed to parse the config JSON
+   */
   @Nullable
-  private DockerConfigTemplate loadDockerConfigTemplate() {
+  private DockerConfigTemplate loadDockerConfigTemplate() throws IOException {
     // Loads the Docker config.
     if (!Files.exists(dockerConfigFile)) {
       return null;
     }
-    try {
-      return JsonTemplateMapper.readJsonFromFile(dockerConfigFile, DockerConfigTemplate.class);
 
-    } catch (IOException ex) {
-      // TODO: Throw some exception about not being able to parse Docker config.
-      return null;
-    }
+    return JsonTemplateMapper.readJsonFromFile(dockerConfigFile, DockerConfigTemplate.class);
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/json/DockerConfigTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/json/DockerConfigTemplate.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.jib.registry.credentials.json;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.cloud.tools.jib.json.JsonTemplate;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.HashMap;
@@ -57,6 +58,7 @@ import javax.annotation.Nullable;
  * @see <a
  *     href="https://www.projectatomic.io/blog/2016/03/docker-credentials-store/">https://www.projectatomic.io/blog/2016/03/docker-credentials-store/</a>
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DockerConfigTemplate implements JsonTemplate {
 
   /** Template for an {@code auth} defined for a registry under {@code auths}. */
@@ -91,8 +93,11 @@ public class DockerConfigTemplate implements JsonTemplate {
    */
   @Nullable
   public String getCredentialHelperFor(String registry) {
-    if (credsStore != null && auths.containsKey(registry)) {
-      return credsStore;
+    if (credsStore != null) {
+      // The registry could be prefixed with the HTTPS protocol.
+      if (auths.containsKey(registry) || auths.containsKey("https://" + registry)) {
+        return credsStore;
+      }
     }
     if (credHelpers.containsKey(registry)) {
       return credHelpers.get(registry);

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetrieverTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetrieverTest.java
@@ -51,7 +51,7 @@ public class DockerConfigCredentialRetrieverTest {
   }
 
   @Test
-  public void testRetrieve_nonexistentDockerConfigFile() {
+  public void testRetrieve_nonexistentDockerConfigFile() throws IOException {
     DockerConfigCredentialRetriever dockerConfigCredentialRetriever =
         new DockerConfigCredentialRetriever("some registry", Paths.get("fake/path"));
 
@@ -59,7 +59,7 @@ public class DockerConfigCredentialRetrieverTest {
   }
 
   @Test
-  public void testRetrieve_hasAuth() {
+  public void testRetrieve_hasAuth() throws IOException {
     DockerConfigCredentialRetriever dockerConfigCredentialRetriever =
         new DockerConfigCredentialRetriever("some registry", dockerConfigFile, null);
 
@@ -69,7 +69,7 @@ public class DockerConfigCredentialRetrieverTest {
   }
 
   @Test
-  public void testRetrieve_useCredsStore() {
+  public void testRetrieve_useCredsStore() throws IOException {
     Mockito.when(
             mockDockerCredentialHelperFactory.withCredentialHelperSuffix("some credential store"))
         .thenReturn(mockDockerCredentialHelper);
@@ -79,12 +79,25 @@ public class DockerConfigCredentialRetrieverTest {
             "just registry", dockerConfigFile, mockDockerCredentialHelperFactory);
 
     Authorization authorization = dockerConfigCredentialRetriever.retrieve();
-    Assert.assertNotNull(authorization);
     Assert.assertEquals(mockAuthorization, authorization);
   }
 
   @Test
-  public void testRetrieve_useCredHelper() {
+  public void testRetrieve_useCredsStore_withProtocol() throws IOException {
+    Mockito.when(
+            mockDockerCredentialHelperFactory.withCredentialHelperSuffix("some credential store"))
+        .thenReturn(mockDockerCredentialHelper);
+
+    DockerConfigCredentialRetriever dockerConfigCredentialRetriever =
+        new DockerConfigCredentialRetriever(
+            "with.protocol", dockerConfigFile, mockDockerCredentialHelperFactory);
+
+    Authorization authorization = dockerConfigCredentialRetriever.retrieve();
+    Assert.assertEquals(mockAuthorization, authorization);
+  }
+
+  @Test
+  public void testRetrieve_useCredHelper() throws IOException {
     Mockito.when(
             mockDockerCredentialHelperFactory.withCredentialHelperSuffix(
                 "another credential helper"))
@@ -95,12 +108,11 @@ public class DockerConfigCredentialRetrieverTest {
             "another registry", dockerConfigFile, mockDockerCredentialHelperFactory);
 
     Authorization authorization = dockerConfigCredentialRetriever.retrieve();
-    Assert.assertNotNull(authorization);
     Assert.assertEquals(mockAuthorization, authorization);
   }
 
   @Test
-  public void testRetrieve_none() {
+  public void testRetrieve_none() throws IOException {
     DockerConfigCredentialRetriever dockerConfigCredentialRetriever =
         new DockerConfigCredentialRetriever("unknown registry", dockerConfigFile);
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/json/DockerConfigTemplateTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/json/DockerConfigTemplateTest.java
@@ -43,6 +43,7 @@ public class DockerConfigTemplateTest {
             .addAuth("some registry", "some auth")
             .addAuth("some other registry", "some other auth")
             .addAuth("just registry", null)
+            .addAuth("http://with.protocol", null)
             .setCredsStore("some credential store")
             .addCredHelper("some registry", "some credential helper")
             .addCredHelper("another registry", "another credential helper");
@@ -74,6 +75,8 @@ public class DockerConfigTemplateTest {
         dockerConfigTemplate.getCredentialHelperFor("some other registry"));
     Assert.assertEquals(
         "some credential store", dockerConfigTemplate.getCredentialHelperFor("just registry"));
+    Assert.assertEquals(
+        "some credential store", dockerConfigTemplate.getCredentialHelperFor("with.protocol"));
     Assert.assertEquals(
         "another credential helper",
         dockerConfigTemplate.getCredentialHelperFor("another registry"));

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/json/DockerConfigTemplateTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/json/DockerConfigTemplateTest.java
@@ -43,7 +43,7 @@ public class DockerConfigTemplateTest {
             .addAuth("some registry", "some auth")
             .addAuth("some other registry", "some other auth")
             .addAuth("just registry", null)
-            .addAuth("http://with.protocol", null)
+            .addAuth("https://with.protocol", null)
             .setCredsStore("some credential store")
             .addCredHelper("some registry", "some credential helper")
             .addCredHelper("another registry", "another credential helper");

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/json/DockerConfigTemplateTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/json/DockerConfigTemplateTest.java
@@ -18,11 +18,8 @@ package com.google.cloud.tools.jib.registry.credentials.json;
 
 import com.google.cloud.tools.jib.json.JsonTemplateMapper;
 import com.google.common.io.Resources;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.Assert;
@@ -30,30 +27,6 @@ import org.junit.Test;
 
 /** Tests for {@link DockerConfigTemplate}. */
 public class DockerConfigTemplateTest {
-
-  @Test
-  public void test_toJson() throws URISyntaxException, IOException {
-    // Loads the expected JSON string.
-    Path jsonFile = Paths.get(Resources.getResource("json/dockerconfig.json").toURI());
-    String expectedJson = new String(Files.readAllBytes(jsonFile), StandardCharsets.UTF_8);
-
-    // Creates the JSON object to serialize.
-    DockerConfigTemplate dockerConfigTemplate =
-        new DockerConfigTemplate()
-            .addAuth("some registry", "some auth")
-            .addAuth("some other registry", "some other auth")
-            .addAuth("just registry", null)
-            .addAuth("https://with.protocol", null)
-            .setCredsStore("some credential store")
-            .addCredHelper("some registry", "some credential helper")
-            .addCredHelper("another registry", "another credential helper");
-
-    // Serializes the JSON object.
-    ByteArrayOutputStream jsonStream = new ByteArrayOutputStream();
-    JsonTemplateMapper.toBlob(dockerConfigTemplate).writeTo(jsonStream);
-
-    Assert.assertEquals(expectedJson, jsonStream.toString());
-  }
 
   @Test
   public void test_fromJson() throws URISyntaxException, IOException {

--- a/jib-core/src/test/resources/json/dockerconfig.json
+++ b/jib-core/src/test/resources/json/dockerconfig.json
@@ -1,1 +1,1 @@
-{"auths":{"some other registry":{"auth":"some other auth"},"some registry":{"auth":"some auth"},"just registry":{}},"credsStore":"some credential store","credHelpers":{"another registry":"another credential helper","some registry":"some credential helper"}}
+{"auths":{"some other registry":{"auth":"some other auth"},"some registry":{"auth":"some auth"},"just registry":{},"https://with.protocol":{}},"credsStore":"some credential store","credHelpers":{"another registry":"another credential helper","some registry":"some credential helper"}}


### PR DESCRIPTION
Docker config can contain `HttpHeaders` field, which we need to ignore to parse correctly.