### PR TITLE
Fixes BuildImageMojoIT to use only project-level cache.

### DIFF
--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIT.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIT.java
@@ -70,7 +70,13 @@ public class BuildImageMojoIT {
 
     verifier.verifyErrorFreeLog();
 
-    Assert.assertTrue(timeOne > timeTwo);
+    Assert.assertTrue(
+        "First build time ("
+            + timeOne
+            + ") is not greater than second build time ("
+            + timeTwo
+            + ")",
+        timeOne > timeTwo);
 
     new Command("docker", "pull", imageReference).run();
     return new Command("docker", "run", imageReference).run();

--- a/jib-maven-plugin/src/test/resources/projects/empty/pom.xml
+++ b/jib-maven-plugin/src/test/resources/projects/empty/pom.xml
@@ -34,6 +34,8 @@
           <credHelpers>
             <credHelper>gcr</credHelper>
           </credHelpers>
+          <!-- Does not have tests use user-level cache for base image layers. -->
+          <useOnlyProjectCache>true</useOnlyProjectCache>
         </configuration>
       </plugin>
     </plugins>

--- a/jib-maven-plugin/src/test/resources/projects/simple/pom.xml
+++ b/jib-maven-plugin/src/test/resources/projects/simple/pom.xml
@@ -45,6 +45,8 @@
             <credHelper>gcr</credHelper>
           </credHelpers>
           <mainClass>com.test.HelloWorld</mainClass>
+          <!-- Does not have tests use user-level cache for base image layers. -->
+          <useOnlyProjectCache>true</useOnlyProjectCache>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Otherwise, the first build time is not necessarily larger than the second build time.

Will release `v0.1.6` after this is merged.