### PR TITLE
Add build failure suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 ## [unreleased]
 
 ### Added
+- Better feedback for build failures
 
 ### Changed
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -114,10 +114,6 @@ public class BuildImageMojo extends AbstractMojo {
   @Parameter(defaultValue = "Docker", required = true)
   private String imageFormat;
 
-  // This is the real <imageFormat> parameter; if <imageFormat> is misconfigured, we want to catch
-  // and handle the error ourselves, so we use a String @Parameter and pass the verified value here.
-  private ImageFormat imageFormatToEnum;
-
   @Parameter(defaultValue = "false", required = true)
   private boolean useOnlyProjectCache;
 
@@ -160,6 +156,7 @@ public class BuildImageMojo extends AbstractMojo {
         RegistryCredentials.from("Maven settings", registryCredentials);
 
     ImageReference targetImageReference = ImageReference.of(registry, repository, tag);
+    ImageFormat imageFormatToEnum = ImageFormat.valueOf(imageFormat);
     BuildConfiguration buildConfiguration =
         BuildConfiguration.builder(new MavenBuildLogger(getLog()))
             .setBaseImage(baseImage)
@@ -297,9 +294,14 @@ public class BuildImageMojo extends AbstractMojo {
       }
     }
     // Validates 'imageFormat'
-    try {
-      imageFormatToEnum = ImageFormat.valueOf(imageFormat);
-    } catch (IllegalArgumentException ex) {
+    boolean validFormat = false;
+    for (ImageFormat format : ImageFormat.values()) {
+      if (imageFormat.equals(format.name())) {
+        validFormat = true;
+        break;
+      }
+    }
+    if (!validFormat) {
       throw new MojoFailureException(
           "<imageFormat> parameter is configured with value '"
               + imageFormat

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/ProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/ProjectProperties.java
@@ -70,7 +70,11 @@ class ProjectProperties {
       return sourceFilesConfiguration;
 
     } catch (IOException ex) {
-      throw new MojoExecutionException("Obtaining project build output files failed", ex);
+      throw new MojoExecutionException(
+          "Obtaining project build output files failed; make sure you have compiled your project "
+              + "before trying to build the image. (Did you accidentally run \"mvn clean "
+              + "jib:build\" instead of \"mvn clean compile jib:build\"?)",
+          ex);
     }
   }
 

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoTest.java
@@ -24,6 +24,7 @@ import com.google.cloud.tools.jib.cache.CacheDirectoryNotOwnedException;
 import com.google.cloud.tools.jib.cache.CacheMetadataCorruptedException;
 import com.google.cloud.tools.jib.registry.RegistryUnauthorizedException;
 import java.io.IOException;
+import java.net.UnknownHostException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
@@ -99,6 +100,26 @@ public class BuildImageMojoTest {
           "Build image failed, perhaps you should make sure your Internet is up and that the registry you are pushing to exists",
           ex.getMessage());
       Assert.assertEquals(mockHttpHostConnectException, ex.getCause());
+    }
+  }
+
+  @Test
+  public void testBuildImage_executionException_unknownHostException()
+      throws InterruptedException, ExecutionException, CacheMetadataCorruptedException, IOException,
+          CacheDirectoryNotOwnedException {
+    UnknownHostException mockUnknownHostException = Mockito.mock(UnknownHostException.class);
+    Mockito.when(mockExecutionException.getCause()).thenReturn(mockUnknownHostException);
+    Mockito.doThrow(mockExecutionException).when(mockBuildImageSteps).run();
+
+    try {
+      testBuildImageMojo.buildImage(mockBuildImageSteps);
+      Assert.fail("buildImage should have thrown an exception");
+
+    } catch (MojoExecutionException ex) {
+      Assert.assertEquals(
+          "Build image failed, perhaps you should make sure that the registry you configured exists/is spelled properly",
+          ex.getMessage());
+      Assert.assertEquals(mockUnknownHostException, ex.getCause());
     }
   }
 


### PR DESCRIPTION
Fixes #27

Adds suggestions for build failures involving:
* "Unknown host" exception when `registry` is misconfigured
* Exception thrown when build output files are missing
* Misconfigured `imageFormat` parameter

Problems left to address:
* Different projects on same registry using invalid credentials from Docker config (#196)
* Build succeeds when main class is invalid (#189)
* Build succeeds with invalid JVM flags (#192)