### PR TITLE
Re-release jib-gradle-plugin v0.1.0.

### DIFF
--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -123,7 +123,6 @@ pluginBundle {
             displayName = 'Jib'
             description = 'Containerize your Java application'
             tags = ['google', 'java', 'containers', 'docker', 'kubernetes', 'microservices']
-            version = '0.1.0'
         }
     }
 }

--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -119,7 +119,7 @@ pluginBundle {
 
     plugins {
         jibPlugin {
-            id = 'com.google.cloud.tools'
+            id = 'com.google.cloud.tools.jib'
             displayName = 'Jib'
             description = 'Containerize your Java application'
             tags = ['google', 'java', 'containers', 'docker', 'kubernetes', 'microservices']

--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -123,6 +123,7 @@ pluginBundle {
             displayName = 'Jib'
             description = 'Containerize your Java application'
             tags = ['google', 'java', 'containers', 'docker', 'kubernetes', 'microservices']
+            version = '0.1.0'
         }
     }
 }

--- a/jib-gradle-plugin/gradle.properties
+++ b/jib-gradle-plugin/gradle.properties
@@ -1,1 +1,1 @@
-version = 0.1.0
+version = 0.1.1-SNAPSHOT

--- a/jib-gradle-plugin/gradle.properties
+++ b/jib-gradle-plugin/gradle.properties
@@ -1,1 +1,1 @@
-version = 0.1.0-SNAPSHOT
+version = 0.1.0


### PR DESCRIPTION
The version in `gradle.properties` needs to be changed rather than the version in the `pluginsBundle`.

Tag `v0.1.0-gradle` has been updated.