### PR TITLE
suggest the use of maven encrypt password when using maven settings to store credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ Configure credential helpers to use by specifying them in the `credHelpers` conf
 
 Registry credentials can be added to your [Maven settings](https://maven.apache.org/settings.html). These credentials will be used if credentials could not be found in any specified Docker credential helpers. 
 
+If you're considering putting credentials in Maven, we highly *recommend* using [maven password encryption](https://maven.apache.org/guides/mini/guide-encryption.html).
+
 *Example `settings.xml`:*
 ```xml
 <settings>
@@ -240,14 +242,14 @@ Registry credentials can be added to your [Maven settings](https://maven.apache.
     <server>
       <id>MY_REGISTRY</id>
       <username>MY_USERNAME</username>
-      <password>MY_SECRET</password>
+      <password>{MY_SECRET}</password>
     </server>
   </servers>
 </settings>
 ```
 
 * The `id` field should be the registry server these credentials are for. 
-* We *do not* recommend putting your raw password in `settings.xml`. Maven 2.1 introduced a facility to encrypt passwords in a user's Maven settings (`~/.m2/settings.xml`). Read more about it [here](https://maven.apache.org/guides/mini/guide-encryption.html).
+* We *do not* recommend putting your raw password in `settings.xml`.
 
 ## How Jib Works
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Registry credentials can be added to your [Maven settings](https://maven.apache.
 ```
 
 * The `id` field should be the registry server these credentials are for. 
-* We *do not* recommend putting your raw password in `settings.xml`. `Maven 2.1` introduced a facility to encrypt passwords in a user's Maven Settings (`~/.m2/settings.xm`l). read more about it [here](https://maven.apache.org/guides/mini/guide-encryption.html)
+* We *do not* recommend putting your raw password in `settings.xml`. Maven 2.1 introduced a facility to encrypt passwords in a user's Maven settings (`~/.m2/settings.xml`). Read more about it [here](https://maven.apache.org/guides/mini/guide-encryption.html).
 
 ## How Jib Works
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Registry credentials can be added to your [Maven settings](https://maven.apache.
 ```
 
 * The `id` field should be the registry server these credentials are for. 
-* We *do not* recommend putting your raw password in `settings.xml`.
+* We *do not* recommend putting your raw password in `settings.xml`. `Maven 2.1` introduced a facility to encrypt passwords in a user's Maven Settings (`~/.m2/settings.xm`l). read more about it [here](https://maven.apache.org/guides/mini/guide-encryption.html)
 
 ## How Jib Works
 


### PR DESCRIPTION
a small PR updating the `RADME.md`, suggesting to user to use maven encrypt password to encrypt their credentials, if they prefer to use maven settings.