### PR TITLE
Updates NullAway and fixes package for Maven.

### DIFF
--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     testCompile 'org.mockito:mockito-core:2.12.0'
 
     // NullAway errorprone plugin
-    apt 'com.uber.nullaway:nullaway:0.3.5'
+    apt 'com.uber.nullaway:nullaway:0.4.2'
     errorprone 'com.google.errorprone:error_prone_core:2.2.0'
 }
 

--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     compile gradleApi()
 
     // NullAway errorprone plugin
-    apt 'com.uber.nullaway:nullaway:0.3.7'
+    apt 'com.uber.nullaway:nullaway:0.4.2'
     errorprone 'com.google.errorprone:error_prone_core:2.2.0'
 }
 

--- a/jib-maven-plugin/pom.xml
+++ b/jib-maven-plugin/pom.xml
@@ -270,12 +270,12 @@
             <path>
               <groupId>com.uber.nullaway</groupId>
               <artifactId>nullaway</artifactId>
-              <version>0.3.5</version>
+              <version>0.4.2</version>
             </path>
           </annotationProcessorPaths>
           <compilerArgs>
             <arg>-Xep:NullAway:ERROR</arg>
-            <arg>-XepOpt:NullAway:AnnotatedPackages=com.uber</arg>
+            <arg>-XepOpt:NullAway:AnnotatedPackages=com.google.cloud.tools</arg>
           </compilerArgs>
         </configuration>
         <dependencies>

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/DockerContextMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/DockerContextMojo.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.jib.maven;
 
 import com.google.cloud.tools.jib.docker.DockerContextGenerator;
+import com.google.common.base.Preconditions;
 import com.google.common.io.InsecureRecursiveDeleteException;
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -36,9 +37,11 @@ import org.apache.maven.project.MavenProject;
 @Mojo(name = "dockercontext", requiresDependencyResolution = ResolutionScope.RUNTIME_PLUS_SYSTEM)
 public class DockerContextMojo extends AbstractMojo {
 
+  @Nullable
   @Parameter(defaultValue = "${project}", readonly = true)
   private MavenProject project;
 
+  @Nullable
   @Parameter(
     property = "jib.dockerDir",
     defaultValue = "${project.build.directory}/jib-dockercontext",
@@ -46,17 +49,23 @@ public class DockerContextMojo extends AbstractMojo {
   )
   private String targetDir;
 
+  @Nullable
   @Parameter(defaultValue = "gcr.io/distroless/java", required = true)
   private String from;
 
   @Parameter private List<String> jvmFlags = Collections.emptyList();
 
-  @Parameter private Map<String, String> environment;
+  @Nullable @Parameter private Map<String, String> environment;
 
-  @Parameter private String mainClass;
+  @Nullable @Parameter private String mainClass;
 
   @Override
   public void execute() throws MojoExecutionException {
+    // These @Nullable parameters should never be actually null.
+    Preconditions.checkNotNull(project);
+    Preconditions.checkNotNull(targetDir);
+    Preconditions.checkNotNull(from);
+
     ProjectProperties projectProperties = new ProjectProperties(project, getLog());
 
     if (mainClass == null) {
@@ -67,6 +76,7 @@ public class DockerContextMojo extends AbstractMojo {
             "add a `mainClass` configuration to jib-maven-plugin");
       }
     }
+    Preconditions.checkNotNull(mainClass);
 
     try {
       new DockerContextGenerator(projectProperties.getSourceFilesConfiguration())


### PR DESCRIPTION
The annotated package configuration for `jib-maven-plugin` was mistakenly `com.uber`, so it wasn't actually doing anything.